### PR TITLE
#14 feature: 약품 상세 정보 조회 기능

### DIFF
--- a/src/main/java/MAP/taboodrug/drug/controller/DrugController.java
+++ b/src/main/java/MAP/taboodrug/drug/controller/DrugController.java
@@ -1,6 +1,7 @@
 package MAP.taboodrug.drug.controller;
 
 import MAP.taboodrug.drug.dto.DrugRequest;
+import MAP.taboodrug.drug.service.DetailInfoService;
 import MAP.taboodrug.drug.service.DrugService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,17 @@ import org.springframework.web.bind.annotation.*;
 public class DrugController {
 
     private final DrugService drugService;
+    private final DetailInfoService detailInfoService;
 
     @ApiOperation(value="약 정보 조회", notes="전달받은 약품에 대한 정보를 JSON형태로 반환")
     @PostMapping("/info")
     public String drugInfoApi(@RequestBody DrugRequest drugRequest) throws Exception {
         return drugService.drugInfoList(drugRequest);
+    }
+
+    @ApiOperation(value="약 상세 정보 조회", notes="전달받은 약품에 대한 상세 정보(주의사항, 부작용 등)를 JSON형태로 반환")
+    @PostMapping("/detail")
+    public String drugDetailInfoApi(@RequestBody DrugRequest drugRequest) throws Exception {
+        return detailInfoService.detailInfoList(drugRequest);
     }
 }

--- a/src/main/java/MAP/taboodrug/drug/domain/DetailInfo.java
+++ b/src/main/java/MAP/taboodrug/drug/domain/DetailInfo.java
@@ -1,0 +1,70 @@
+package MAP.taboodrug.drug.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import java.util.ArrayList;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class DetailInfo {
+
+    @Id
+    @Column(name = "itemName")
+    private String itemName;
+
+    private String entpName;
+
+    @Lob
+    private String efficacy;
+
+    @Lob
+    private String useMethod;
+
+    @Lob
+    private String warn;
+
+    @Lob
+    private String caution;
+
+    @Lob
+    private String interact;
+
+    @Lob
+    private String sideEffect;
+
+    @Lob
+    private String depositMethod;
+
+    public DetailInfo(String itemName, String entpName, String efficacy, String useMethod, String warn, String caution, String interact, String sideEffect, String depositMethod) {
+        this.itemName = itemName;
+        this.entpName = entpName;
+        this.efficacy = efficacy;
+        this.useMethod = useMethod;
+        this.warn = warn;
+        this.caution = caution;
+        this.interact = interact;
+        this.sideEffect = sideEffect;
+        this.depositMethod = depositMethod;
+    }
+
+    public void setDrugName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public void setDetailInfo(ArrayList<String> info) {
+        this.entpName = info.get(0);
+        this.efficacy = info.get(1);
+        this.useMethod = info.get(2);
+        this.warn = info.get(3);
+        this.caution = info.get(4);
+        this.interact = info.get(5);
+        this.sideEffect = info.get(6);
+        this.depositMethod = info.get(7);
+    }
+}

--- a/src/main/java/MAP/taboodrug/drug/repository/DetailInfoRepository.java
+++ b/src/main/java/MAP/taboodrug/drug/repository/DetailInfoRepository.java
@@ -1,0 +1,10 @@
+package MAP.taboodrug.drug.repository;
+
+import MAP.taboodrug.drug.domain.DetailInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DetailInfoRepository extends JpaRepository<DetailInfo, String> {
+    Optional<DetailInfo> findDetailInfoByItemName(String itemName);
+}

--- a/src/main/java/MAP/taboodrug/drug/service/DetailInfoService.java
+++ b/src/main/java/MAP/taboodrug/drug/service/DetailInfoService.java
@@ -1,0 +1,81 @@
+package MAP.taboodrug.drug.service;
+
+import MAP.taboodrug.drug.domain.DetailInfo;
+import MAP.taboodrug.drug.dto.DrugRequest;
+import MAP.taboodrug.drug.repository.DetailInfoRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Element;
+
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DetailInfoService {
+
+    @Value("${easyDrugInfoUrl}")
+    private String drugInfoUrl;
+
+    @Value("${easyDrugInfoKey}")
+    private String drugInfoKey;
+
+    private final CommonService commonService;
+
+    private final DetailInfoRepository detailInfoRepository;
+
+    // Entity 객체를 JSON으로 변환해주는 매퍼
+    private final ObjectMapper objectMapper;
+
+    public String detailInfoList(DrugRequest drugRequest) throws Exception {
+        // DB에 전달받은 약품 이름에 대한 정보가 있다면, 그대로 반환
+        // 그렇지 않다면 setData() 호출
+        log.info("detailInfoList(), 입력받은 약품명: {}", drugRequest.getDrugName());
+
+        Optional<DetailInfo> detailInfo = detailInfoRepository.findDetailInfoByItemName(drugRequest.getDrugName());
+
+        if (detailInfo.isEmpty())
+            return setData(drugRequest);
+
+        return objectMapper.writeValueAsString(detailInfo);
+    }
+
+    // 서버 최초 실행 시 1회 실행하여 해당 약품에 대한 모든 정보를 DB에 저장
+    private String setData(DrugRequest drugRequest) throws Exception {
+        String result = drugInfoUrl + "?" + URLEncoder.encode("serviceKey", "UTF-8") + "=" + drugInfoKey + /*Service Key*/
+                "&" + URLEncoder.encode("pageNo", "UTF-8") + "=" + URLEncoder.encode(String.valueOf(1), "UTF-8") + /*페이지 번호, 기본 값 1*/
+                "&" + URLEncoder.encode("numOfRows", "UTF-8") + "=" + URLEncoder.encode(String.valueOf(1), "UTF-8") + /*한 페이지 결과 수, 기본 값 1*/
+                "&" + URLEncoder.encode("itemName", "UTF-8") + "=" + URLEncoder.encode(drugRequest.getDrugName(), "UTF-8") + /*품목명*/
+                "&" + URLEncoder.encode("type", "UTF-8") + "=" + URLEncoder.encode("xml", "UTF-8");
+
+        Element eElement = commonService.initElement(commonService.initDocument(result));
+
+        ArrayList<String> resultList = new ArrayList<>();
+
+        String str;
+        resultList.add(commonService.getTagValue("entpName", eElement));
+        resultList.add((str = commonService.getTagValue("efcyQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+        resultList.add((str = commonService.getTagValue("useMethodQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+        resultList.add((str = commonService.getTagValue("atpnWarnQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+        resultList.add((str = commonService.getTagValue("atpnQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+        resultList.add((str = commonService.getTagValue("intrcQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+        resultList.add((str = commonService.getTagValue("seQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+        resultList.add((str = commonService.getTagValue("depositMethodQesitm", eElement)) == null ? "" : str.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", ""));
+
+        DetailInfo detailInfo = new DetailInfo();
+
+        detailInfo.setDrugName(drugRequest.getDrugName());
+        detailInfo.setDetailInfo(resultList);
+
+        log.info("상세 정보 저장할 약품 이름: {}", detailInfo.getItemName());
+        detailInfoRepository.save(detailInfo);
+
+        return objectMapper.writeValueAsString(detailInfo);
+    }
+
+}


### PR DESCRIPTION
-  `식품의약품안전처_의약품개요정보(e약은요)` 공공데이터 API를 이용한 약품 상세 정보 조회 서비스 구현
- 상세 정보 저장하기 위해 `DetailInfo` domain 생성 (field: `itemName`, `entpName`, `efficacy`, `useMethod`, `warn`, `caution`, `interact`, `sideEffect`, `depositMethod`)